### PR TITLE
Add support for a sub-provider to roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 ```hcl
 module "assumed_roles" {
   source              = "git::https://github.com/cloudposse/terraform-aws-iam-assumed-roles.git?ref=master"
+  providers           = {
+    aws     = "aws"
+    aws.sub = "aws.prod"
+  }
   namespace           = "cp"
   stage               = "prod"
   admin_name          = "admin"
@@ -74,6 +78,7 @@ Available targets:
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| use_sub_provider | Whether or not to use the aws.sub provider when creating roles | string | `false` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -66,6 +66,10 @@ usage: |-
   ```hcl
   module "assumed_roles" {
     source              = "git::https://github.com/cloudposse/terraform-aws-iam-assumed-roles.git?ref=master"
+    providers           = {
+      aws     = "aws"
+      aws.sub = "aws.prod"
+    }
     namespace           = "cp"
     stage               = "prod"
     admin_name          = "admin"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,7 @@
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| use_sub_provider | Whether or not to use the aws.sub provider when creating roles | string | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {}
+
+provider "aws" {
+  alias = "sub"
+}
+
 module "admin_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
@@ -132,6 +138,7 @@ resource "aws_iam_group" "admin" {
 }
 
 resource "aws_iam_role" "admin" {
+  provider           = "${var.use_sub_provider ? aws.sub : aws}"
   name               = "${module.admin_label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.role_trust.json}"
 }
@@ -195,6 +202,7 @@ resource "aws_iam_group" "readonly" {
 }
 
 resource "aws_iam_role" "readonly" {
+  provider           = "${var.use_sub_provider ? aws.sub : aws}"
   name               = "${module.readonly_label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.role_trust.json}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "readonly_user_names" {
   default     = []
   description = "Optional list of IAM user names to add to the readonly group"
 }
+
+variable "use_sub_provider" {
+  type        = "string"
+  default     = false
+  description = "Whether or not to use the aws.sub provider when creating roles"
+}


### PR DESCRIPTION
What
------

Add an option to use a sub-provider for roles, so they can be created in a different account than the users who can assume it.

Why
------

We have a use-case where we need admin and readonly roles in subaccounts, which people access via the main account. With this change, we can use this module to do this easily by using multiple providers. 