### PR TITLE
Add enabled var to booloean creation of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -86,6 +85,7 @@ Available targets:
 | admin_user_names | Optional list of IAM user names to add to the admin group | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
+| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | readonly_name | Name for the readonly group and role (e.g. `readonly`) | string | `readonly` | no |
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
@@ -97,12 +97,12 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | group_admin_arn | Admin group ARN |
-| group_admin_id | Group outputs |
+| group_admin_id | Admin group ID |
 | group_admin_name | Admin group name |
 | group_readonly_arn | Readonly group ARN |
 | group_readonly_id | Readonly group ID |
 | group_readonly_name | Readonly group name |
-| role_admin_arn | Role outputs |
+| role_admin_arn | Admin role ARN |
 | role_admin_name | Admin role name |
 | role_readonly_arn | Readonly role ARN |
 | role_readonly_name | Readonly role name |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -7,6 +6,7 @@
 | admin_user_names | Optional list of IAM user names to add to the admin group | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
+| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | readonly_name | Name for the readonly group and role (e.g. `readonly`) | string | `readonly` | no |
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
@@ -18,12 +18,12 @@
 | Name | Description |
 |------|-------------|
 | group_admin_arn | Admin group ARN |
-| group_admin_id | Group outputs |
+| group_admin_id | Admin group ID |
 | group_admin_name | Admin group name |
 | group_readonly_arn | Readonly group ARN |
 | group_readonly_id | Readonly group ID |
 | group_readonly_name | Readonly group name |
-| role_admin_arn | Role outputs |
+| role_admin_arn | Admin role ARN |
 | role_admin_name | Admin role name |
 | role_readonly_arn | Readonly role ARN |
 | role_readonly_name | Readonly role name |

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,8 @@ module "readonly_label" {
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "role_trust" {
+  count = "${local.enabled ? 1 : 0}"
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -38,6 +40,8 @@ data "aws_iam_policy_document" "role_trust" {
 }
 
 data "aws_iam_policy_document" "manage_mfa" {
+  count = "${local.enabled ? 1 : 0}"
+
   statement {
     sid = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
 
@@ -89,6 +93,8 @@ data "aws_iam_policy_document" "manage_mfa" {
 }
 
 data "aws_iam_policy_document" "allow_change_password" {
+  count = "${local.enabled ? 1 : 0}"
+
   statement {
     actions   = ["iam:ChangePassword"]
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
@@ -102,126 +108,152 @@ data "aws_iam_policy_document" "allow_change_password" {
 
 # Admin config
 
+locals {
+  enabled             = "${var.enabled == "true" ? true : false }"
+  admin_user_names    = "${length(var.admin_user_names) > 0 ? true : false}"
+  readonly_user_names = "${length(var.readonly_user_names) > 0 ? true : false}"
+}
+
 resource "aws_iam_policy" "manage_mfa_admin" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.admin_label.id}-permit-mfa"
   description = "Allow admin users to manage Virtual MFA Devices"
-  policy      = "${data.aws_iam_policy_document.manage_mfa.json}"
+  policy      = "${join("", data.aws_iam_policy_document.manage_mfa.*.json)}"
 }
 
 resource "aws_iam_policy" "allow_change_password_admin" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.admin_label.id}-permit-change-password"
   description = "Allow admin users to change password"
-  policy      = "${data.aws_iam_policy_document.allow_change_password.json}"
+  policy      = "${join("", data.aws_iam_policy_document.allow_change_password.*.json)}"
 }
 
 data "aws_iam_policy_document" "assume_role_admin" {
+  count = "${local.enabled ? 1 : 0}"
+
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["${aws_iam_role.admin.arn}"]
+    resources = ["${join("", aws_iam_role.admin.*.arn)}"]
   }
 }
 
 resource "aws_iam_policy" "assume_role_admin" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.admin_label.id}-permit-assume-role"
   description = "Allow assuming admin role"
-  policy      = "${data.aws_iam_policy_document.assume_role_admin.json}"
+  policy      = "${join("", data.aws_iam_policy_document.assume_role_admin.*.json)}"
 }
 
 resource "aws_iam_group" "admin" {
-  name = "${module.admin_label.id}"
+  count = "${local.enabled ? 1 : 0}"
+  name  = "${module.admin_label.id}"
 }
 
 resource "aws_iam_role" "admin" {
+  count              = "${local.enabled ? 1 : 0}"
   name               = "${module.admin_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.role_trust.json}"
+  assume_role_policy = "${join("", data.aws_iam_policy_document.role_trust.*.json)}"
 }
 
 resource "aws_iam_group_policy_attachment" "assume_role_admin" {
-  group      = "${aws_iam_group.admin.name}"
-  policy_arn = "${aws_iam_policy.assume_role_admin.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.admin.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.assume_role_admin.*.arn)}"
 }
 
 resource "aws_iam_group_policy_attachment" "manage_mfa_admin" {
-  group      = "${aws_iam_group.admin.name}"
-  policy_arn = "${aws_iam_policy.manage_mfa_admin.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.admin.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.manage_mfa_admin.*.arn)}"
 }
 
 resource "aws_iam_group_policy_attachment" "allow_chage_password_admin" {
-  group      = "${aws_iam_group.admin.name}"
-  policy_arn = "${aws_iam_policy.allow_change_password_admin.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.admin.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.allow_change_password_admin.*.arn)}"
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
-  role       = "${aws_iam_role.admin.name}"
+  count      = "${local.enabled ? 1 : 0}"
+  role       = "${join("", aws_iam_role.admin.*.name)}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
 resource "aws_iam_group_membership" "admin" {
-  count = "${length(var.admin_user_names) > 0 ? 1 : 0}"
+  count = "${local.enabled && local.admin_user_names ? 1 : 0}"
   name  = "${module.admin_label.id}"
-  group = "${aws_iam_group.admin.id}"
+  group = "${join("", aws_iam_group.admin.*.id)}"
   users = ["${var.admin_user_names}"]
 }
 
 # Readonly config
 
 resource "aws_iam_policy" "manage_mfa_readonly" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.readonly_label.id}-permit-mfa"
   description = "Allow readonly users to manage Virtual MFA Devices"
-  policy      = "${data.aws_iam_policy_document.manage_mfa.json}"
+  policy      = "${join("", data.aws_iam_policy_document.manage_mfa.*.json)}"
 }
 
 resource "aws_iam_policy" "allow_change_password_readonly" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.readonly_label.id}-permit-change-password"
   description = "Allow readonly users to change password"
-  policy      = "${data.aws_iam_policy_document.allow_change_password.json}"
+  policy      = "${join("", data.aws_iam_policy_document.allow_change_password.*.json)}"
 }
 
 data "aws_iam_policy_document" "assume_role_readonly" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["${aws_iam_role.readonly.arn}"]
+    resources = ["${join("", aws_iam_role.readonly.*.arn)}"]
   }
 }
 
 resource "aws_iam_policy" "assume_role_readonly" {
+  count       = "${local.enabled ? 1 : 0}"
   name        = "${module.readonly_label.id}-permit-assume-role"
   description = "Allow assuming readonly role"
-  policy      = "${data.aws_iam_policy_document.assume_role_readonly.json}"
+  policy      = "${join("", data.aws_iam_policy_document.assume_role_readonly.*.json)}"
 }
 
 resource "aws_iam_group" "readonly" {
-  name = "${module.readonly_label.id}"
+  count = "${local.enabled ? 1 : 0}"
+  name  = "${module.readonly_label.id}"
 }
 
 resource "aws_iam_role" "readonly" {
+  count              = "${local.enabled ? 1 : 0}"
   name               = "${module.readonly_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.role_trust.json}"
+  assume_role_policy = "${join("", data.aws_iam_policy_document.role_trust.*.json)}"
 }
 
 resource "aws_iam_group_policy_attachment" "assume_role_readonly" {
-  group      = "${aws_iam_group.readonly.name}"
-  policy_arn = "${aws_iam_policy.assume_role_readonly.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.readonly.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.assume_role_readonly.*.arn)}"
 }
 
 resource "aws_iam_group_policy_attachment" "manage_mfa_readonly" {
-  group      = "${aws_iam_group.readonly.name}"
-  policy_arn = "${aws_iam_policy.manage_mfa_readonly.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.readonly.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.manage_mfa_readonly.*.arn)}"
 }
 
 resource "aws_iam_group_policy_attachment" "allow_change_password_readonly" {
-  group      = "${aws_iam_group.readonly.name}"
-  policy_arn = "${aws_iam_policy.allow_change_password_readonly.arn}"
+  count      = "${local.enabled ? 1 : 0}"
+  group      = "${join("", aws_iam_group.readonly.*.name)}"
+  policy_arn = "${join("", aws_iam_policy.allow_change_password_readonly.*.arn)}"
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {
-  role       = "${aws_iam_role.readonly.name}"
+  count      = "${local.enabled ? 1 : 0}"
+  role       = "${join("", aws_iam_role.readonly.*.name)}"
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 resource "aws_iam_group_membership" "readonly" {
-  count = "${length(var.readonly_user_names) > 0 ? 1 : 0}"
+  count = "${local.enabled && local.readonly_user_names ? 1 : 0}"
   name  = "${module.readonly_label.id}"
-  group = "${aws_iam_group.readonly.id}"
+  group = "${join("", aws_iam_group.readonly.*.id)}"
   users = ["${var.readonly_user_names}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,53 +1,53 @@
 # Group outputs
 #
 output "group_admin_id" {
-  value       = "${aws_iam_group.admin.id}"
+  value       = "${join("", aws_iam_group.admin.*.id)}"
   description = "Admin group ID"
 }
 
 output "group_admin_arn" {
-  value       = "${aws_iam_group.admin.arn}"
+  value       = "${join("", aws_iam_group.admin.*.arn)}"
   description = "Admin group ARN"
 }
 
 output "group_admin_name" {
-  value       = "${aws_iam_group.admin.name}"
+  value       = "${join("", aws_iam_group.admin.*.name)}"
   description = "Admin group name"
 }
 
 output "group_readonly_id" {
-  value       = "${aws_iam_group.readonly.id}"
+  value       = "${join("",  aws_iam_group.readonly.*.id)}"
   description = "Readonly group ID"
 }
 
 output "group_readonly_arn" {
-  value       = "${aws_iam_group.readonly.arn}"
+  value       = "${join("", aws_iam_group.readonly.*.arn)}"
   description = "Readonly group ARN"
 }
 
 output "group_readonly_name" {
-  value       = "${aws_iam_group.readonly.name}"
+  value       = "${join("", aws_iam_group.readonly.*.name)}"
   description = "Readonly group name"
 }
 
 # Role outputs
 #
 output "role_admin_arn" {
-  value       = "${aws_iam_role.admin.arn}"
+  value       = "${join("", aws_iam_role.admin.*.arn)}"
   description = "Admin role ARN"
 }
 
 output "role_admin_name" {
-  value       = "${aws_iam_role.admin.name}"
+  value       = "${join("", aws_iam_role.admin.*.name)}"
   description = "Admin role name"
 }
 
 output "role_readonly_arn" {
-  value       = "${aws_iam_role.readonly.arn}"
+  value       = "${join("", aws_iam_role.readonly.*.arn)}"
   description = "Readonly role ARN"
 }
 
 output "role_readonly_name" {
-  value       = "${aws_iam_role.readonly.name}"
+  value       = "${join("", aws_iam_role.readonly.*.name)}"
   description = "Readonly role name"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
+variable "enabled" {
+  type        = "string"
+  description = "Whether to create these resources"
+  default     = "true"
+}
+
 variable "stage" {
   type        = "string"
   description = "Stage (e.g. `prod`, `dev`, `staging`)"

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "namespace" {
 
 variable "enabled" {
   type        = "string"
-  description = "Whether to create these resources"
+  description = "Set to false to prevent the module from creating any resources"
   default     = "true"
 }
 


### PR DESCRIPTION
## what

This commit adds an “enabled” flag and defaults to true.

## why

So we can enable/disable creation of these resources. Should resolve https://github.com/cloudposse/terraform-aws-iam-assumed-roles/issues/11