### PR TITLE
Enable flag output splat

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,53 +1,53 @@
 # Group outputs
 #
 output "group_admin_id" {
-  value       = "${aws_iam_group.admin.id}"
+  value       = "${join("", aws_iam_group.admin.id.*.id)}"
   description = "Admin group ID"
 }
 
 output "group_admin_arn" {
-  value       = "${aws_iam_group.admin.arn}"
+  value       = "${join("", aws_iam_group.admin.*.arn)}"
   description = "Admin group ARN"
 }
 
 output "group_admin_name" {
-  value       = "${aws_iam_group.admin.name}"
+  value       = "${join("", aws_iam_group.admin.*.name)}"
   description = "Admin group name"
 }
 
 output "group_readonly_id" {
-  value       = "${aws_iam_group.readonly.id}"
+  value       = "${join("",  aws_iam_group.readonly.*.id)}"
   description = "Readonly group ID"
 }
 
 output "group_readonly_arn" {
-  value       = "${aws_iam_group.readonly.arn}"
+  value       = "${join("", aws_iam_group.readonly.*.arn)}"
   description = "Readonly group ARN"
 }
 
 output "group_readonly_name" {
-  value       = "${aws_iam_group.readonly.name}"
+  value       = "${join("", aws_iam_group.readonly.*.name)}"
   description = "Readonly group name"
 }
 
 # Role outputs
 #
 output "role_admin_arn" {
-  value       = "${aws_iam_role.admin.arn}"
+  value       = "${join("", aws_iam_role.admin.*.arn)}"
   description = "Admin role ARN"
 }
 
 output "role_admin_name" {
-  value       = "${aws_iam_role.admin.name}"
+  value       = "${join("", aws_iam_role.admin.*.name)}"
   description = "Admin role name"
 }
 
 output "role_readonly_arn" {
-  value       = "${aws_iam_role.readonly.arn}"
+  value       = "${join("", aws_iam_role.readonly.*.arn)}"
   description = "Readonly role ARN"
 }
 
 output "role_readonly_name" {
-  value       = "${aws_iam_role.readonly.name}"
+  value       = "${join("", aws_iam_role.readonly.*.name)}"
   description = "Readonly role name"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
+variable "enabled" {
+  type        = "string"
+  description = "Whether to create these resources"
+  default     = "true"
+}
+
 variable "stage" {
   type        = "string"
   description = "Stage (e.g. `prod`, `dev`, `staging`)"


### PR DESCRIPTION
## what

See https://github.com/cloudposse/terraform-aws-iam-assumed-roles/pull/12 for context

This PR needs to be rebased onto https://github.com/cloudposse/terraform-aws-iam-assumed-roles/pull/12 once merged and applied.

## why

To avoid problems in downstream modules and to stop errors being raised:

```
Warning: output "group_admin_id": must use splat syntax to access aws_iam_group.admin attribute "id", because it has "count" set; use aws_iam_group.admin.*.id to obtain a list of the attributes across all instances
```
