### PR TITLE
Add URLs for switching roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Available targets:
 | readonly_name | Name for the readonly group and role (e.g. `readonly`) | string | `readonly` | no |
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| switchrole_url | URL to the IAM console to switch to a role | string | `https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s&displayName=%s` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 
 ## Outputs
@@ -106,6 +107,8 @@ Available targets:
 | role_admin_name | Admin role name |
 | role_readonly_arn | Readonly role ARN |
 | role_readonly_name | Readonly role name |
+| switchrole_admin_url | URL to the IAM console to switch to the admin role |
+| switchrole_readonly_url | URL to the IAM console to switch to the readonly role |
 
 
 
@@ -192,7 +195,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,6 +11,7 @@
 | readonly_name | Name for the readonly group and role (e.g. `readonly`) | string | `readonly` | no |
 | readonly_user_names | Optional list of IAM user names to add to the readonly group | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| switchrole_url | URL to the IAM console to switch to a role | string | `https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s&displayName=%s` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 
 ## Outputs
@@ -27,4 +28,6 @@
 | role_admin_name | Admin role name |
 | role_readonly_arn | Readonly role ARN |
 | role_readonly_name | Readonly role name |
+| switchrole_admin_url | URL to the IAM console to switch to the admin role |
+| switchrole_readonly_url | URL to the IAM console to switch to the readonly role |
 

--- a/main.tf
+++ b/main.tf
@@ -331,3 +331,8 @@ resource "aws_iam_group_membership" "readonly" {
   group = "${join("", aws_iam_group.readonly.*.id)}"
   users = ["${var.readonly_user_names}"]
 }
+
+locals {
+  role_readonly_name = "${join("", aws_iam_role.readonly.*.name)}"
+  role_admin_name    = "${join("", aws_iam_role.admin.*.name)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,10 +56,10 @@ output "role_readonly_name" {
 
 output "switchrole_admin_url" {
   description = "URL to the IAM console to switch to the admin role"
-  value       = "${format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_admin_name, local.role_admin_name)}"
+  value       = "${local.enabled ? format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_admin_name, local.role_admin_name) : ""}"
 }
 
 output "switchrole_readonly_url" {
   description = "URL to the IAM console to switch to the readonly role"
-  value       = "${format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_readonly_name, local.role_readonly_name)}"
+  value       = "${local.enabled ? format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_readonly_name, local.role_readonly_name) : ""}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
+#
 # Group outputs
 #
 output "group_admin_id" {
@@ -30,6 +31,7 @@ output "group_readonly_name" {
   description = "Readonly group name"
 }
 
+#
 # Role outputs
 #
 output "role_admin_arn" {
@@ -38,7 +40,7 @@ output "role_admin_arn" {
 }
 
 output "role_admin_name" {
-  value       = "${join("", aws_iam_role.admin.*.name)}"
+  value       = "${local.role_admin_name}"
   description = "Admin role name"
 }
 
@@ -48,6 +50,16 @@ output "role_readonly_arn" {
 }
 
 output "role_readonly_name" {
-  value       = "${join("", aws_iam_role.readonly.*.name)}"
+  value       = "${local.role_readonly_name}"
   description = "Readonly role name"
+}
+
+output "switchrole_admin_url" {
+  description = "URL to the IAM console to switch to the admin role"
+  value       = "${format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_admin_name, local.role_admin_name)}"
+}
+
+output "switchrole_readonly_url" {
+  description = "URL to the IAM console to switch to the readonly role"
+  value       = "${format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_readonly_name, local.role_readonly_name)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,9 @@ variable "readonly_user_names" {
   default     = []
   description = "Optional list of IAM user names to add to the readonly group"
 }
+
+variable "switchrole_url" {
+  type        = "string"
+  description = "URL to the IAM console to switch to a role"
+  default     = "https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s&displayName=%s"
+}


### PR DESCRIPTION
## what
* Add (2) new outputs with URLs for switching roles in the IAM console

## why
* These cryptic URLs are hard for users to come up with for first time users

![image](https://user-images.githubusercontent.com/52489/50581363-d86e9400-0e0d-11e9-9508-00ec03c1d46e.png)
