### PR TITLE
Update HCL to tf12 syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,28 @@
 module "admin_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.admin_name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.admin_name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 module "readonly_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.readonly_name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.readonly_name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_iam_policy_document" "role_trust" {
-  count = "${local.enabled ? 1 : 0}"
+  count = local.enabled ? 1 : 0
 
   statement {
     actions = ["sts:AssumeRole"]
@@ -40,7 +41,7 @@ data "aws_iam_policy_document" "role_trust" {
 }
 
 data "aws_iam_policy_document" "manage_mfa" {
-  count = "${local.enabled ? 1 : 0}"
+  count = local.enabled ? 1 : 0
 
   statement {
     sid = "AllowUsersToCreateEnableResyncTheirOwnVirtualMFADevice"
@@ -111,7 +112,7 @@ data "aws_iam_policy_document" "manage_mfa" {
 }
 
 data "aws_iam_policy_document" "allow_change_password" {
-  count = "${local.enabled ? 1 : 0}"
+  count = local.enabled ? 1 : 0
 
   statement {
     actions = ["iam:ChangePassword"]
@@ -161,178 +162,185 @@ data "aws_iam_policy_document" "allow_key_management" {
 # Admin config
 
 locals {
-  enabled             = "${var.enabled == "true" ? true : false }"
-  admin_user_names    = "${length(var.admin_user_names) > 0 ? true : false}"
-  readonly_user_names = "${length(var.readonly_user_names) > 0 ? true : false}"
+  enabled             = var.enabled == "true" ? true : false
+  admin_user_names    = length(var.admin_user_names) > 0 ? true : false
+  readonly_user_names = length(var.readonly_user_names) > 0 ? true : false
 }
 
 resource "aws_iam_policy" "manage_mfa_admin" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.admin_label.id}-permit-mfa"
   description = "Allow admin users to manage Virtual MFA Devices"
-  policy      = "${join("", data.aws_iam_policy_document.manage_mfa.*.json)}"
+  policy      = join("", data.aws_iam_policy_document.manage_mfa.*.json)
 }
 
 resource "aws_iam_policy" "allow_change_password_admin" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.admin_label.id}-permit-change-password"
   description = "Allow admin users to change password"
-  policy      = "${join("", data.aws_iam_policy_document.allow_change_password.*.json)}"
+  policy = join(
+    "",
+    data.aws_iam_policy_document.allow_change_password.*.json,
+  )
 }
 
 resource "aws_iam_policy" "allow_key_management_admin" {
   name        = "${module.admin_label.id}-allow-key-management"
   description = "Allow admin users to manage their own access keys"
-  policy      = "${data.aws_iam_policy_document.allow_key_management.json}"
+  policy      = data.aws_iam_policy_document.allow_key_management.json
 }
 
 data "aws_iam_policy_document" "assume_role_admin" {
-  count = "${local.enabled ? 1 : 0}"
+  count = local.enabled ? 1 : 0
 
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["${join("", aws_iam_role.admin.*.arn)}"]
+    resources = [join("", aws_iam_role.admin.*.arn)]
   }
 }
 
 resource "aws_iam_policy" "assume_role_admin" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.admin_label.id}-permit-assume-role"
   description = "Allow assuming admin role"
-  policy      = "${join("", data.aws_iam_policy_document.assume_role_admin.*.json)}"
+  policy      = join("", data.aws_iam_policy_document.assume_role_admin.*.json)
 }
 
 resource "aws_iam_group" "admin" {
-  count = "${local.enabled ? 1 : 0}"
-  name  = "${module.admin_label.id}"
+  count = local.enabled ? 1 : 0
+  name  = module.admin_label.id
 }
 
 resource "aws_iam_role" "admin" {
-  count              = "${local.enabled ? 1 : 0}"
-  name               = "${module.admin_label.id}"
-  assume_role_policy = "${join("", data.aws_iam_policy_document.role_trust.*.json)}"
+  count              = local.enabled ? 1 : 0
+  name               = module.admin_label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.role_trust.*.json)
 }
 
 resource "aws_iam_group_policy_attachment" "assume_role_admin" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.admin.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.assume_role_admin.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.admin.*.name)
+  policy_arn = join("", aws_iam_policy.assume_role_admin.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "manage_mfa_admin" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.admin.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.manage_mfa_admin.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.admin.*.name)
+  policy_arn = join("", aws_iam_policy.manage_mfa_admin.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "allow_chage_password_admin" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.admin.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.allow_change_password_admin.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.admin.*.name)
+  policy_arn = join("", aws_iam_policy.allow_change_password_admin.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "key_management_admin" {
-  group      = "${aws_iam_group.admin.name}"
-  policy_arn = "${aws_iam_policy.allow_key_management_admin.arn}"
+  group      = aws_iam_group.admin[0].name
+  policy_arn = aws_iam_policy.allow_key_management_admin.arn
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
-  count      = "${local.enabled ? 1 : 0}"
-  role       = "${join("", aws_iam_role.admin.*.name)}"
+  count      = local.enabled ? 1 : 0
+  role       = join("", aws_iam_role.admin.*.name)
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
 resource "aws_iam_group_membership" "admin" {
-  count = "${local.enabled && local.admin_user_names ? 1 : 0}"
-  name  = "${module.admin_label.id}"
-  group = "${join("", aws_iam_group.admin.*.id)}"
-  users = ["${var.admin_user_names}"]
+  count = local.enabled && local.admin_user_names ? 1 : 0
+  name  = module.admin_label.id
+  group = join("", aws_iam_group.admin.*.id)
+  users = var.admin_user_names
 }
 
 # Readonly config
 
 resource "aws_iam_policy" "manage_mfa_readonly" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.readonly_label.id}-permit-mfa"
   description = "Allow readonly users to manage Virtual MFA Devices"
-  policy      = "${join("", data.aws_iam_policy_document.manage_mfa.*.json)}"
+  policy      = join("", data.aws_iam_policy_document.manage_mfa.*.json)
 }
 
 resource "aws_iam_policy" "allow_change_password_readonly" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.readonly_label.id}-permit-change-password"
   description = "Allow readonly users to change password"
-  policy      = "${join("", data.aws_iam_policy_document.allow_change_password.*.json)}"
+  policy = join(
+    "",
+    data.aws_iam_policy_document.allow_change_password.*.json,
+  )
 }
 
 resource "aws_iam_policy" "allow_key_management_readonly" {
   name        = "${module.readonly_label.id}-permit-manage-keys"
   description = "Allow readonly users to manage their own access keys"
-  policy      = "${data.aws_iam_policy_document.allow_key_management.json}"
+  policy      = data.aws_iam_policy_document.allow_key_management.json
 }
 
 data "aws_iam_policy_document" "assume_role_readonly" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["${join("", aws_iam_role.readonly.*.arn)}"]
+    resources = [join("", aws_iam_role.readonly.*.arn)]
   }
 }
 
 resource "aws_iam_policy" "assume_role_readonly" {
-  count       = "${local.enabled ? 1 : 0}"
+  count       = local.enabled ? 1 : 0
   name        = "${module.readonly_label.id}-permit-assume-role"
   description = "Allow assuming readonly role"
-  policy      = "${join("", data.aws_iam_policy_document.assume_role_readonly.*.json)}"
+  policy      = join("", data.aws_iam_policy_document.assume_role_readonly.*.json)
 }
 
 resource "aws_iam_group" "readonly" {
-  count = "${local.enabled ? 1 : 0}"
-  name  = "${module.readonly_label.id}"
+  count = local.enabled ? 1 : 0
+  name  = module.readonly_label.id
 }
 
 resource "aws_iam_role" "readonly" {
-  count              = "${local.enabled ? 1 : 0}"
-  name               = "${module.readonly_label.id}"
-  assume_role_policy = "${join("", data.aws_iam_policy_document.role_trust.*.json)}"
+  count              = local.enabled ? 1 : 0
+  name               = module.readonly_label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.role_trust.*.json)
 }
 
 resource "aws_iam_group_policy_attachment" "assume_role_readonly" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.readonly.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.assume_role_readonly.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.readonly.*.name)
+  policy_arn = join("", aws_iam_policy.assume_role_readonly.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "manage_mfa_readonly" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.readonly.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.manage_mfa_readonly.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.readonly.*.name)
+  policy_arn = join("", aws_iam_policy.manage_mfa_readonly.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "allow_change_password_readonly" {
-  count      = "${local.enabled ? 1 : 0}"
-  group      = "${join("", aws_iam_group.readonly.*.name)}"
-  policy_arn = "${join("", aws_iam_policy.allow_change_password_readonly.*.arn)}"
+  count      = local.enabled ? 1 : 0
+  group      = join("", aws_iam_group.readonly.*.name)
+  policy_arn = join("", aws_iam_policy.allow_change_password_readonly.*.arn)
 }
 
 resource "aws_iam_group_policy_attachment" "key_management_readonly" {
-  group      = "${aws_iam_group.readonly.name}"
-  policy_arn = "${aws_iam_policy.allow_key_management_readonly.arn}"
+  group      = aws_iam_group.readonly[0].name
+  policy_arn = aws_iam_policy.allow_key_management_readonly.arn
 }
 
 resource "aws_iam_role_policy_attachment" "readonly" {
-  count      = "${local.enabled ? 1 : 0}"
-  role       = "${join("", aws_iam_role.readonly.*.name)}"
+  count      = local.enabled ? 1 : 0
+  role       = join("", aws_iam_role.readonly.*.name)
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 resource "aws_iam_group_membership" "readonly" {
-  count = "${local.enabled && local.readonly_user_names ? 1 : 0}"
-  name  = "${module.readonly_label.id}"
-  group = "${join("", aws_iam_group.readonly.*.id)}"
-  users = ["${var.readonly_user_names}"]
+  count = local.enabled && local.readonly_user_names ? 1 : 0
+  name  = module.readonly_label.id
+  group = join("", aws_iam_group.readonly.*.id)
+  users = var.readonly_user_names
 }
 
 locals {
-  role_readonly_name = "${join("", aws_iam_role.readonly.*.name)}"
-  role_admin_name    = "${join("", aws_iam_role.admin.*.name)}"
+  role_readonly_name = join("", aws_iam_role.readonly.*.name)
+  role_admin_name    = join("", aws_iam_role.admin.*.name)
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,32 +2,32 @@
 # Group outputs
 #
 output "group_admin_id" {
-  value       = "${join("", aws_iam_group.admin.*.id)}"
+  value       = join("", aws_iam_group.admin.*.id)
   description = "Admin group ID"
 }
 
 output "group_admin_arn" {
-  value       = "${join("", aws_iam_group.admin.*.arn)}"
+  value       = join("", aws_iam_group.admin.*.arn)
   description = "Admin group ARN"
 }
 
 output "group_admin_name" {
-  value       = "${join("", aws_iam_group.admin.*.name)}"
+  value       = join("", aws_iam_group.admin.*.name)
   description = "Admin group name"
 }
 
 output "group_readonly_id" {
-  value       = "${join("",  aws_iam_group.readonly.*.id)}"
+  value       = join("", aws_iam_group.readonly.*.id)
   description = "Readonly group ID"
 }
 
 output "group_readonly_arn" {
-  value       = "${join("", aws_iam_group.readonly.*.arn)}"
+  value       = join("", aws_iam_group.readonly.*.arn)
   description = "Readonly group ARN"
 }
 
 output "group_readonly_name" {
-  value       = "${join("", aws_iam_group.readonly.*.name)}"
+  value       = join("", aws_iam_group.readonly.*.name)
   description = "Readonly group name"
 }
 
@@ -35,31 +35,42 @@ output "group_readonly_name" {
 # Role outputs
 #
 output "role_admin_arn" {
-  value       = "${join("", aws_iam_role.admin.*.arn)}"
+  value       = join("", aws_iam_role.admin.*.arn)
   description = "Admin role ARN"
 }
 
 output "role_admin_name" {
-  value       = "${local.role_admin_name}"
+  value       = local.role_admin_name
   description = "Admin role name"
 }
 
 output "role_readonly_arn" {
-  value       = "${join("", aws_iam_role.readonly.*.arn)}"
+  value       = join("", aws_iam_role.readonly.*.arn)
   description = "Readonly role ARN"
 }
 
 output "role_readonly_name" {
-  value       = "${local.role_readonly_name}"
+  value       = local.role_readonly_name
   description = "Readonly role name"
 }
 
 output "switchrole_admin_url" {
   description = "URL to the IAM console to switch to the admin role"
-  value       = "${local.enabled ? format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_admin_name, local.role_admin_name) : ""}"
+  value = local.enabled ? format(
+    var.switchrole_url,
+    data.aws_caller_identity.current.account_id,
+    local.role_admin_name,
+    local.role_admin_name,
+  ) : ""
 }
 
 output "switchrole_readonly_url" {
   description = "URL to the IAM console to switch to the readonly role"
-  value       = "${local.enabled ? format(var.switchrole_url, data.aws_caller_identity.current.account_id, local.role_readonly_name, local.role_readonly_name) : ""}"
+  value = local.enabled ? format(
+    var.switchrole_url,
+    data.aws_caller_identity.current.account_id,
+    local.role_readonly_name,
+    local.role_readonly_name,
+  ) : ""
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,63 +1,64 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   description = "Set to false to prevent the module from creating any resources"
   default     = "true"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "admin_name" {
-  type        = "string"
+  type        = string
   default     = "admin"
   description = "Name for the admin group and role (e.g. `admin`)"
 }
 
 variable "readonly_name" {
-  type        = "string"
+  type        = string
   default     = "readonly"
   description = "Name for the readonly group and role (e.g. `readonly`)"
 }
 
 variable "admin_user_names" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Optional list of IAM user names to add to the admin group"
 }
 
 variable "readonly_user_names" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Optional list of IAM user names to add to the readonly group"
 }
 
 variable "switchrole_url" {
-  type        = "string"
+  type        = string
   description = "URL to the IAM console to switch to a role"
   default     = "https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s&displayName=%s"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR updates the HCL of the module to the new Terraform 0.12 syntax. This fixes various errors that occur when using the module with Terraform 0.12.x